### PR TITLE
DaGroup::AddItem error callback convert to std::function

### DIFF
--- a/examples/c++/DaConsole/DaConsole.cpp
+++ b/examples/c++/DaConsole/DaConsole.cpp
@@ -32,6 +32,7 @@
  // INCLUDES
  //-----------------------------------------------------------------------------
 #include <iostream>
+#include <functional>
 #include <tchar.h> 
 #include <string>
 #include <vector>
@@ -129,10 +130,10 @@ void MyDataCallbackClass::DataChange(
 //-----------------------------------------------------------------------------
 // This handler is called for all items which cannot be added successfully.
 //-----------------------------------------------------------------------------
-void AddItemErrHandler(const Technosoftware::DaAeHdaClient::DaItemDefinition& itemDef, Technosoftware::Base::Status res)
+auto AddItemErrHandler = [](const Technosoftware::DaAeHdaClient::DaItemDefinition& itemDef, Technosoftware::Base::Status res)
 {
     cout << "   Cannot add item '" << itemDef.ItemIdentifier << "': " << res.ToString() << endl;
-}
+};
 
 
 //-----------------------------------------------------------------------------

--- a/include/DaAeHdaClient/Da/DaGroup.h
+++ b/include/DaAeHdaClient/Da/DaGroup.h
@@ -27,6 +27,7 @@
 #include "Base/Handles.h"
 #include "Base/Status.h"
 
+#include <functional>
 
 namespace Technosoftware
 {
@@ -36,6 +37,7 @@ namespace Technosoftware
         class DaItem;
         class DaIDataCallback;
         class DaGroupImpl;
+
 
         /**
          * @class   DaGroup
@@ -220,7 +222,7 @@ namespace Technosoftware
 
             Base::Status AddItems(  DaItemDefinitions& itemDefinitions,
                                     vector<DaItem*>& items,
-                                    void(*errorHandler)(const DaItemDefinition& itemDefinition, Base::Status status) = nullptr);
+                                    const std::function<void(const DaItemDefinition&, Base::Status)>& errorHandler = {});
 
             /**
              * @fn  Base::Status DaGroup::Read(vector<DaItem*>& items, bool fromCache = true);

--- a/src/Technosoftware/DaAeHdaClient/Da/DaGroup.cpp
+++ b/src/Technosoftware/DaAeHdaClient/Da/DaGroup.cpp
@@ -20,6 +20,7 @@
 
 #include <vector>
 
+
 #include "OpcInternal.h"
 #include "DaAeHdaClient/Da/DaGroup.h"
 #include "DaGroupImpl.h"
@@ -28,6 +29,7 @@
 #include "DaAeHdaClient/Da/DaItem.h"
 
 #include "Base/Exception.h"
+
 
 namespace Technosoftware
 {
@@ -86,7 +88,9 @@ namespace Technosoftware
 
         Base::Status DaGroup::AddItems(DaItemDefinitions& itemDefinitions,
             vector<DaItem*>& items,
-            void(*errorHandler)(const DaItemDefinition& itemDefinitions, Base::Status status)) {
+            const std::function<void(const DaItemDefinition&, Base::Status)>& errorHandler
+                
+                ) {
             return impl_->AddItems(itemDefinitions, items, errorHandler);
         }
 
@@ -255,7 +259,7 @@ namespace Technosoftware
         //----------------------------------------------------------------------------------------------------------------------
         Technosoftware::Base::Status DaGroupImpl::AddItems(DaItemDefinitions& ItemDefs,
             vector<DaItem*>& arItems,
-            void(*pfnErrHandler)(const DaItemDefinition& ItemDef, Technosoftware::Base::Status res))
+            const std::function<void(const DaItemDefinition&, Base::Status)>& pfnErrHandler)
         {
             Technosoftware::Base::Status res;
             DaItem*  pItem = NULL;

--- a/src/Technosoftware/DaAeHdaClient/Da/DaGroupImpl.h
+++ b/src/Technosoftware/DaAeHdaClient/Da/DaGroupImpl.h
@@ -128,7 +128,7 @@ namespace Technosoftware
             inline HRESULT SetActive(bool fActive);
             inline Technosoftware::Base::Status AddItems(DaItemDefinitions& ItemDefs,
                 vector<DaItem*>& arItems,
-                void(*pfnErrHandler)(const DaItemDefinition&, Technosoftware::Base::Status));
+                const std::function<void(const DaItemDefinition&, Base::Status)>& pfnErrHandler);
             inline Technosoftware::Base::Status Read(vector<DaItem*>& arItems, bool fFromCache);
             inline Technosoftware::Base::Status Write(vector<DaItem*>& arItems);
             inline Technosoftware::Base::Status SetDataSubscription(DaIDataCallback* pIUserDataCallback);


### PR DESCRIPTION
This is the kind of change I want to make - it makes the callbacks a lot more C++ rather than C. If it works for you, I'll convert the rest of the callbacks.